### PR TITLE
Fix enum parsing and support emscripten

### DIFF
--- a/tools/generator.nim
+++ b/tools/generator.nim
@@ -191,6 +191,8 @@ proc genConstants*(output: var string) =
       else:
         addConstant(name, value)
 
+  header.close()
+
   output.add("\n# Constants and Enums\n")
 
   output.add("const\n")
@@ -206,10 +208,9 @@ proc genConstants*(output: var string) =
   for enumName, parsedEnum in enums.pairs():
     output.add("  {enumName}* {{.pure, size: int32.sizeof.}} = enum\n".fmt)
     output.add(parsedEnum.doc)
+    assert parsedEnum.items.len > 1, "The " & enumName & " enum has " & $parsedEnum.items.len & " items, it should have more!"
     for name, value in parsedEnum.items.pairs():
       output.add("    {name} = {value}\n".fmt)
-
-  header.close()
 
 proc genTypes*(output: var string) =
   let header = newFileStream("src/glfw/private/glfw/include/GLFW/glfw3.h", fmRead)

--- a/tools/generator.nim
+++ b/tools/generator.nim
@@ -188,13 +188,14 @@ proc genConstants*(output: var string) =
   for define in defines:
     if define.group.len == 1:
       for name, value in define.group.pairs():
+        var newName = define.enumName & name
         output.add("const\n")
-        if name == "GLFWCursor":
-          let newName = "GLFWCursorSpecial"
+        if newName == "GLFWCursor":
+          newName = "GLFWCursorSpecial"
           output.add("  {newName}* = {value} ## Originally GLFW_CURSOR but conflicts with GLFWCursor type\n".fmt)
-          continue
-        output.add("  {name}* = {value}\n".fmt)
-        output.add(define.doc)
+        else:
+          output.add("  {newName}* = {value}\n".fmt)
+          output.add(define.doc)
     elif define.group.len > 1:
       output.add("type\n")
       output.add("  {define.enumName}* {{.pure, size: int32.sizeof.}} = enum\n".fmt)

--- a/tools/utils.nim
+++ b/tools/utils.nim
@@ -24,10 +24,13 @@ when defined(glfwDLL):
   else:
     const glfw_dll* = "libglfw.so.3"
 else:
-  {.compile: "glfw/private/glfw/src/vulkan.c".}
+  when not defined(emscripten):
+    {.compile: "glfw/private/glfw/src/vulkan.c".}
 
   # Thanks to ephja for making this build system
-  when defined(windows):
+  when defined(emscripten):
+    {.passL: "-s USE_GLFW=3".}
+  elif defined(windows):
     {.passC: "-D_GLFW_WIN32",
       passL: "-lopengl32 -lgdi32",
       compile: "glfw/private/glfw/src/win32_init.c",
@@ -78,11 +81,12 @@ else:
       compile: "glfw/private/glfw/src/osmesa_context.c",
       compile: "glfw/private/glfw/src/posix_thread.c".}
 
-  {.compile: "glfw/private/glfw/src/context.c",
-    compile: "glfw/private/glfw/src/init.c",
-    compile: "glfw/private/glfw/src/input.c",
-    compile: "glfw/private/glfw/src/monitor.c",
-    compile: "glfw/private/glfw/src/window.c".}
+  when not defined(emscripten):
+    {.compile: "glfw/private/glfw/src/context.c",
+      compile: "glfw/private/glfw/src/init.c",
+      compile: "glfw/private/glfw/src/input.c",
+      compile: "glfw/private/glfw/src/monitor.c",
+      compile: "glfw/private/glfw/src/window.c".}
 
 when defined(vulkan):
   import vulkan


### PR DESCRIPTION
This PR fixes enum parsing. Right now, it parses and outputs enums in a single pass, which only works if all enum items are next to each other in glfw.h. This currently fails because `GLFW_MOUSE_PASSTHROUGH` is declared in a different place than the other `GLFW_MOUSE` constants. The fix is to store all the parsed enums in a table, and only create the Nim output at the very end.

I also added support for emscripten. I'm working on doing the same for `nimgl/opengl` but it will be more difficult since we need to make it work more like the [opengl package](https://github.com/nim-lang/opengl) when `emscripten` is defined, since it doesn't like the dynamic way of retrieving proc addresses. I'll try to figure that out when I have time.