### PR TITLE
glfwGetError should accept a pointer to a cstring instead of a cstringarray

### DIFF
--- a/src/glfw.nim
+++ b/src/glfw.nim
@@ -1668,7 +1668,7 @@ proc glfwGetVersionString*(): cstring {.importc: "glfwGetVersionString".}
   ## @since Added in version 3.0.
   ##
   ## @ingroup init
-proc glfwGetError*(description: cstringArray): int32 {.importc: "glfwGetError".}
+proc glfwGetError*(description: ptr cstring): int32 {.importc: "glfwGetError".}
   ## @brief Returns and clears the last error for the calling thread.
   ##
   ## This function returns and clears the error code of the last


### PR DESCRIPTION
The docs for GLFW indicate that this function should accept as a parameter:

`[in]	description	Where to store the error description pointer, or NULL.`

It also states that: 

```The returned string is allocated and freed by GLFW. You should not free it yourself. It is guaranteed to be valid only until the next error occurs or the library is terminated.```

I think there's a bit of a inaccuracy in that last part of the documentation, because a string isn't returned it's just allocated by GLFW and the pointer is made to point at it.

If we take a look at some of the [example GLFW code itself](https://github.com/glfw/glfw/blob/8e23579842005761d3a4668b72ca524a34ef7b01/examples/windows.c#L34-L45), we can see that it is indeed the case that a cstring's address is intended to be passed to the function:

```
int main(int argc, char** argv)
{
    int xpos, ypos, height;
    const char* description;
    GLFWwindow* windows[4];


    if (!glfwInit())
    {
        glfwGetError(&description);
        printf("Error: %s\n", description);
        exit(EXIT_FAILURE);
    }
...
```

So this PR just addresses this. I'm not sure how much it potentially breaks for users.